### PR TITLE
Fix "expected length of user_data" error when applying the example

### DIFF
--- a/code/terraform/06-production-grade-infrastructure/small-modules/modules/cluster/asg-rolling-deploy/variables.tf
+++ b/code/terraform/06-production-grade-infrastructure/small-modules/modules/cluster/asg-rolling-deploy/variables.tf
@@ -58,7 +58,7 @@ variable "health_check_type" {
 variable "user_data" {
   description = "The User Data script to run in each Instance at boot"
   type        = string
-  default     = ""
+  default     = "Hello World"
 }
 
 variable "custom_tags" {


### PR DESCRIPTION
Hello :wave:

When running the ASG example in the chapter 6 I am getting an error on the length of the `user_data`:
```
➜ terraform apply
data.aws_vpc.default: Refreshing state...
data.aws_subnet_ids.default: Refreshing state...

Error: expected length of user_data to be in the range (1 - 16384), got

  on ../../modules/cluster/asg-rolling-deploy/main.tf line 1, in resource "aws_launch_configuration" "example":
   1: resource "aws_launch_configuration" "example" {
```

This error also shows up using your version of the code so I assumed this was not due to typos on my side.

I have fixed this error replacing the default value of this variable with `"Hello World"`.
