### PR TITLE
fix typo terraform -> opa

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All the code is in the [code](/code) folder. The code examples are organized fir
 by chapter. For example, if you're looking at an example of Terraform code in Chapter 2, you'll find it in the 
 [code/terraform/02-intro-to-terraform-syntax](code/terraform/02-intro-to-terraform-syntax) folder; if you're looking at 
 an OPA (Rego) example in Chapter 9, you'll find it in the 
-[code/terraform/09-testing-terraform-code](code/terraform/09-testing-terraform-code) folder.
+[code/opa/09-testing-terraform-code](code/opa/09-testing-terraform-code) folder.
 
 Since this code comes from a book about Terraform, the vast majority of the code consists of Terraform examples in the 
 [code/terraform folder](/code/terraform).


### PR DESCRIPTION
Maybe a copy paste mistake?

intended to reference opa folder, but added terraform folder again in the README, fixing that minor typo.