### PR TITLE
Update Kubernetes version

### DIFF
--- a/code/terraform/07-working-with-multiple-providers/modules/services/eks-cluster/main.tf
+++ b/code/terraform/07-working-with-multiple-providers/modules/services/eks-cluster/main.tf
@@ -13,7 +13,7 @@ terraform {
 resource "aws_eks_cluster" "cluster" {
   name     = var.name
   role_arn = aws_iam_role.cluster.arn
-  version  = "1.21"
+  version  = "1.23"
 
   vpc_config {
     subnet_ids = data.aws_subnets.default.ids


### PR DESCRIPTION
Updated Kubernetes to oldest version supported by AWS

[https://aws.amazon.com/about-aws/whats-new/2023/10/amazon-eks-support-kubernetes-versions-preview/](url)

updated version 1.21 >> 1.23